### PR TITLE
Remove Google Analytics for Venkat Group

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,9 +37,6 @@ roles:
 # Number of news stories on the front page.
 front_page_news: 8
 
-# Google Analytics
-google_analytics: G-C0RVH5ZRNY
-
 # make pages for the _projects folder
 collections:
   projects:


### PR DESCRIPTION
Can you remove our google analytics id from your site (Feel free to replace it with your own)?

Best,

Alex


Thank you for the pull request. You are awesome! 🎉
## To-Do List

- [ ] All status checks are green; if not [try fixing them](https://github.com/BattModels/group-website/blob/master/docs/making_changes.md#status-checks)
- [ ] Add peer-reviewers, [if needed](https://github.com/BattModels/group-website/blob/master/docs/making_changes.md#peer-review), to the request
- [ ] All reviewers have approved the pull request

Once the above steps are complete, please merge the pull request.

## Getting help

If you get stuck, open an [issue](https://github.com/BattModels/group-website/issues), and we'll get it sorted out.

> Once your changes are merged, they will be live on the internet in ~10 minutes
